### PR TITLE
existingDocumentWithID instead of documentWithID in Profile.m

### DIFF
--- a/Models/Profile.m
+++ b/Models/Profile.m
@@ -33,7 +33,7 @@
     NSString* profileDocId = [@"p:" stringByAppendingString:userID];
     CBLDocument *doc;
     if (profileDocId.length > 0)
-        doc = [db documentWithID: profileDocId];
+        doc = [db existingDocumentWithID: profileDocId];
     return doc ? [Profile modelForDocument: doc] : nil;
 }
 


### PR DESCRIPTION
when looking for a Profile doc in DB we should use existingDocumentWithID function instead of documentWithID because documentWithID creates an empty instance of CBLDocument and gives a false positive result
