### PR TITLE
fix(auth): delete SyncGatewaySession cookie when logging out

### DIFF
--- a/ToDoLite/AppDelegate.m
+++ b/ToDoLite/AppDelegate.m
@@ -338,6 +338,7 @@
     [self setCurrentUserId:nil];
     [self stopReplication];
     [self setCurrentDatabase:nil];
+    [self removeSessionCookie];
     
     [self performSelector:@selector(replaceRootViewController:)
                withObject:[self.window.rootViewController.storyboard instantiateInitialViewController]
@@ -418,6 +419,17 @@
     [guestDB deleteDatabase:&error];
     if (error) {
         NSLog(@"Migrating guest data, deleting the guest database has an error : %@", [error description]);
+    }
+}
+
+// Clear the SyncGateway session cookie when logging out
+// In the future the replication object may handle that: https://github.com/couchbase/couchbase-lite-ios/issues/543
+- (void)removeSessionCookie {
+    NSHTTPCookieStorage *cookieJar = NSHTTPCookieStorage.sharedHTTPCookieStorage;
+    for (NSHTTPCookie *aCookie in cookieJar.cookies) {
+        if ([aCookie.name  isEqual: @"SyncGatewaySession"]) {
+            [cookieJar deleteCookie:aCookie];
+        }
     }
 }
 


### PR DESCRIPTION
Delete the SyncGateway session cookie.
This fixes log in/log out for the time being.
Feature in progress to handle that automatically [#543](https://github.com/couchbase/couchbase-lite-ios/issues/543)

Deleting the cookie may sometimes produce the warning:

```
16:23:05.285‖ WARNING: CBL_Pusher[http://demo.mobile.couchbase.com/todolite]: Unable to save remote checkpoint: Error Domain=CBLHTTP Code=401 "401 unauthorized" UserInfo=0x7f9b3bd6a150 {NSURL=http://demo.mobile.couchbase.com/todolite/_local/acc396601fc0f2472b2521b06861dcf24dd9aa4a, NSLocalizedFailureReason=unauthorized, NSLocalizedDescription=401 unauthorized}
```