### PR TITLE
Change Live Query in MasterVC to use vanilla KVO to show an example without CBLUITableSource

### DIFF
--- a/ToDoLite/Base.lproj/Main.storyboard
+++ b/ToDoLite/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="PWY-sp-JlJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14E11f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="PWY-sp-JlJ">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -128,7 +128,7 @@
                                     </tableViewCell>
                                 </prototypes>
                                 <connections>
-                                    <outlet property="dataSource" destination="ZXK-Fp-26F" id="qhP-eh-m2R"/>
+                                    <outlet property="dataSource" destination="0pl-Gm-9PQ" id="Uhu-oJ-gKc"/>
                                     <outlet property="delegate" destination="0pl-Gm-9PQ" id="16v-Uw-BJh"/>
                                 </connections>
                             </tableView>
@@ -154,17 +154,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="dataSource" destination="ZXK-Fp-26F" id="jLx-pE-u0C"/>
                         <outlet property="loginButton" destination="2wq-at-h3o" id="9DC-uY-etN"/>
                         <outlet property="tableView" destination="b4q-Vq-rxR" id="28f-tQ-e43"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="USj-28-9V1" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <customObject id="ZXK-Fp-26F" customClass="CBLUITableSource">
-                    <connections>
-                        <outlet property="tableView" destination="b4q-Vq-rxR" id="VST-vK-WYQ"/>
-                    </connections>
-                </customObject>
             </objects>
             <point key="canvasLocation" x="657" y="-630"/>
         </scene>

--- a/ToDoLite/MasterViewController.h
+++ b/ToDoLite/MasterViewController.h
@@ -11,11 +11,10 @@
 
 @class DetailViewController;
 
-@interface MasterViewController : UIViewController <CBLUITableDelegate>
+@interface MasterViewController : UIViewController <UITableViewDataSource>
 
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *loginButton;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (strong, nonatomic) IBOutlet CBLUITableSource *dataSource;
 @property (strong, nonatomic) DetailViewController *detailViewController;
 
 @end

--- a/ToDoLite/MasterViewController.m
+++ b/ToDoLite/MasterViewController.m
@@ -63,6 +63,8 @@ static void *listsQueryContext = &listsQueryContext;
 - (void)viewWillDisappear:(BOOL)animated {
     AppDelegate *app = [[UIApplication sharedApplication] delegate];
     [app removeObserver:self forKeyPath:@"database" context:nil];
+
+    [self.liveQuery removeObserver:self forKeyPath:@"rows" context:listsQueryContext];
 }
 
 - (void)didReceiveMemoryWarning {
@@ -183,6 +185,7 @@ static void *listsQueryContext = &listsQueryContext;
     AppDelegate *app = [[UIApplication sharedApplication] delegate];
     self.database = app.database;
     
+    [self.liveQuery removeObserver:self forKeyPath:@"rows" context:listsQueryContext];
     if (self.database != nil) {
         self.liveQuery = [List queryListsInDatabase:self.database].asLiveQuery;
         [self.liveQuery addObserver:self forKeyPath:@"rows" options:0 context:listsQueryContext];


### PR DESCRIPTION
In this View Controller, we show an example of a Live Query
and KVO to update the Table View accordingly when data changed.
See DetailViewController and ShareViewController for
examples of a Live Query used with the CBLUITableSource api.